### PR TITLE
fixed return type of i2c_timeout()

### DIFF
--- a/i2c.c
+++ b/i2c.c
@@ -142,7 +142,7 @@ uint8_t i2c_tx_byte(uint8_t byteData)
     return status;
 }
 
-bool i2c_timeout(void)
+int8_t i2c_timeout(void)
 {
     uint8_t time = TIMEOUT;
     int8_t status = BUS_DISCONNECTED;

--- a/i2c.h
+++ b/i2c.h
@@ -10,7 +10,7 @@
 #ifndef i2c_h
 #define i2c_h
 
-#define F_I2C 25000L
+#define F_I2C 100000LL
 #define TRANSMISSION_SUCCESS -1
 #define TRANSMISSION_ERROR -2
 #define BUS_CONNECTED -3
@@ -89,7 +89,7 @@ uint8_t i2c_tx_byte(uint8_t byteData);
  * Returns:
  *     Timeout status
  */
-bool i2c_timeout(void);
+int8_t i2c_timeout(void);
 
 /*
  * Receive byte of data


### PR DESCRIPTION
In function i2c_timeout() the returt type was "bool" which cannot pass "int8_t" value.
To handle high CPU frequency , the i2c frequency was increased to 100 KHz.