### PR TITLE
Fix `rx_byte` & `tx_address`

### DIFF
--- a/i2c.c
+++ b/i2c.c
@@ -54,10 +54,8 @@ uint8_t i2c_tx_address(uint8_t address)
     int8_t status = 0;
 
     TWDR = (address << 1) | masterMode;
-    /* clear start command to release bus as master */
-    TWCR &= ~(1 << TWSTA);
-    /* clear interrupt flag */
-    TWCR |=  (1 << TWINT);
+    /* clear interrupt and enable */
+    TWCR = (1 << TWINT | 1 << TWEN);
 
     /* wait until address transmitted */
     while (!(TWCR & (1 << TWINT)));
@@ -162,14 +160,8 @@ uint8_t i2c_rx_byte(bool response)
 {
     int8_t status;
 
-    if (response == ACK) {
-        TWCR |= (1 << TWEA); // generate ACK
-    } else {
-        TWCR &= ~(1 << TWEA); // generate NACK
-    }
-
     /* clear interrupt flag */
-    TWCR |= (1 << TWINT);
+    TWCR |= (1 << TWINT) | ((response & 0xFE) << TWEA);
 
     /* detect bus time-out */
     if (i2c_timeout() != BUS_DISCONNECTED) {
@@ -206,5 +198,5 @@ void i2c_tx_stop(void)
     /* clear interrupt flag, issue stop command (cleared automatically) */
     TWCR |= (1 << TWINT) | (1 << TWSTO);
 
-    while (!(TWCR & (1 << TWSTO))); // wait until stop transmitted
+    while ((TWCR & (1 << TWSTO))); // wait until stop transmitted
 }

--- a/i2c.c
+++ b/i2c.c
@@ -160,8 +160,8 @@ uint8_t i2c_rx_byte(bool response)
 {
     int8_t status;
 
-    /* clear interrupt flag */
-    TWCR |= (1 << TWINT) | ((response & 0xFE) << TWEA);
+    /* clear interrupt flag and set response type */
+    TWCR = (1 << TWINT) | ((response & 0xFE) << TWEA) | (1 << TWEN);
 
     /* detect bus time-out */
     if (i2c_timeout() != BUS_DISCONNECTED) {


### PR DESCRIPTION
Hello,

I was using your library while testing the AVR's TWI controller on QEmu and noticed a couple small mistakes in your `i2c_rx_byte` and `i2c_tx_address` routines. This is an issue that I would guess might not crop on hardware, but because of the emulation I was using for testing, I was getting unexpected results and decided to make this pull request to make you aware. 

In both of these functions you write to the `TWCR` register twice before "starting" the transfer of data:

[i2c_tx_address](https://github.com/prestonsn/AtmegaXX-I2C-Library/blob/77038eb4a85653fdb6020dacda56e900a9842dee/i2c.c#L57C1-L60C27)

[i2c_rx_byte](https://github.com/prestonsn/AtmegaXX-I2C-Library/blob/77038eb4a85653fdb6020dacda56e900a9842dee/i2c.c#L165-L172)

Since these writes are writing back the value read from the register, if the `INT` bit is high when the value is read, then the writeback is clearing the interrupt bit, and the second writeback is explicitly clearing it again. This should technically cause another read, or a second write of `TWDR` to occur. On hardware, its possible the first read/write would happen slow enough that the second doesn't take place because the `INT` bit wouldn't be high during the second writeback. 

To address the issue, I simply combined the writes into a single line, which fixed the issue. 